### PR TITLE
feat: add miracl reranking task for german

### DIFF
--- a/mteb/tasks/Reranking/MIRACLReranking.py
+++ b/mteb/tasks/Reranking/MIRACLReranking.py
@@ -1,0 +1,26 @@
+from collections import defaultdict
+
+import datasets
+
+from mteb.abstasks.AbsTaskReranking import AbsTaskReranking
+
+
+class MIRACLReranking(AbsTaskReranking):
+    @property
+    def description(self):
+        return {
+            'name': 'MIRACL',
+            'hf_hub_name': 'jinaai/miracl',
+            'reference': 'https://project-miracl.github.io/',
+            'description': (
+                'MIRACL (Multilingual Information Retrieval Across a Continuum of Languages) is a multilingual '
+                'retrieval dataset that focuses on search across 18 different languages. This task focuses on '
+                'the German subset, uing the dev set containing 305 queries.'
+            ),
+            'type': 'Reranking',
+            'category': 's2p',
+            'eval_splits': ['dev'],
+            'eval_langs': ['de'],
+            'main_score': 'map',
+            'revision': '8741c3b61cd36ed9ca1b3d4203543a41793239e2',
+        }

--- a/mteb/tasks/Reranking/MIRACLReranking.py
+++ b/mteb/tasks/Reranking/MIRACLReranking.py
@@ -1,7 +1,3 @@
-from collections import defaultdict
-
-import datasets
-
 from mteb.abstasks.AbsTaskReranking import AbsTaskReranking
 
 

--- a/mteb/tasks/Reranking/__init__.py
+++ b/mteb/tasks/Reranking/__init__.py
@@ -3,3 +3,4 @@ from .MindSmallReranking import *
 from .SciDocsReranking import *
 from .StackOverflowDupQuestions import *
 from .CMTEBReranking import *
+from .MIRACLReranking import *


### PR DESCRIPTION
This PR adds the MIRACL German dev set as a Reranking task to the MTEB. It contains 305 queries, and each query has on average 4 positive passages and 13 negative passages.