### PR TITLE
fix: Use MTEB_SINGLE_GPU environment variable also in BeIRTask.py

### DIFF
--- a/mteb/abstasks/BeIRTask.py
+++ b/mteb/abstasks/BeIRTask.py
@@ -23,7 +23,7 @@ class BeIRTask(AbsTask):
         USE_HF_DATASETS = False
 
         # TODO @nouamane: move non-distributed to `HFDataLoader`
-        if os.getenv("RANK", None) is not None:
+        if os.getenv("RANK", None) is not None and os.getenv("MTEB_SINGLE_GPU", "false").lower() == "false":
             if self.description["beir_name"].startswith("cqadupstack"):
                 raise ImportError("CQADupstack is incompatible with BEIR's HFDataLoader in a distributed setting")
             from beir.datasets.data_loader_hf import HFDataLoader 


### PR DESCRIPTION
This is related to the changes in #9. In large-scale training we encountered some exception due to datasets being of the wrong type in MTEB. This seems to originate from BeIRTask.py, where HF datasets are used when parallel evaluation is enabled via the `RANK` variable. In this PR we add a check of the `MTEB_SINGLE_GPU` variable from #9 to avoid this branch. I searched for occurences of `os.getenv("RANK")` in the MTEB codebase and we should now cover everything relevant.